### PR TITLE
fixes errors thrown when xmrig returns null

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "requests>=2.18.4",
-        "prometheus_client>=0.2.0",
+        "prometheus_client>=0.2.0,<=0.2.0",
     ],
     entry_points={
         "console_scripts": [

--- a/xmrig_exporter/collector.py
+++ b/xmrig_exporter/collector.py
@@ -28,22 +28,24 @@ class XmrigCollector(object):
         j = requests.get(self.url, headers=headers).json()
         ids = {"worker_id": j["worker_id"]}
         for i, v in enumerate(j["hashrate"]["total"]):
-            metrics.append(self.make_metric(
-                False,
-                self._prefix + "hashrate%d" % i,
-                "Overall Hashrate",
-                v,
-                **ids))
-        for tidx, t in enumerate(j["hashrate"]["threads"]):
-            for i, v in enumerate(t):
-                labels = {"thread": tidx}
-                labels.update(ids)
+            if not v is None:
                 metrics.append(self.make_metric(
                     False,
-                    self._prefix + "thread_hashrate%d" % i,
-                    "Thread Hashrate",
+                    self._prefix + "hashrate%d" % i,
+                    "Overall Hashrate",
                     v,
-                    **labels))
+                    **ids))
+        for tidx, t in enumerate(j["hashrate"]["threads"]):
+            for i, v in enumerate(t):
+                if not v is None:
+                    labels = {"thread": tidx}
+                    labels.update(ids)
+                    metrics.append(self.make_metric(
+                        False,
+                        self._prefix + "thread_hashrate%d" % i,
+                        "Thread Hashrate",
+                        v,
+                        **labels))
         metrics.append(self.make_metric(
             False,
             self._prefix + "diff_current",


### PR DESCRIPTION
When XMRIG just starts it returns null on some of the hashrate values. i.e:
```json
 "hashrate": {
        "total": [5345.36, null, null],
        "highest": 5346.14,
        "threads": [
            [445.33, null, null],
            [444.77, null, null],
        ]
    }
```

This causes the following error on `xmrig-exporter`
```
TypeError: must be real number, not NoneType
```
This PR adds a null check so that the metrics are not added until the value is not null.

In order to successfully build the image, I had to lock the dependency to `prometheus`. It appears that the API has changed and I currently don't have the time to investigate it further.
I have uploaded my fork to docker hub on `lchaia/xmrig-exporter` if you'd like to test it.

Thank you.